### PR TITLE
Added the DSC function to the Scatterer class. This allows us to use …

### DIFF
--- a/pySCATMECH/scatterer.py
+++ b/pySCATMECH/scatterer.py
@@ -99,3 +99,45 @@ class Free_Space_Scatterer(Model):
             Mueller matrix extinction cross section
         """
         return MuellerMatrix(SCATPY.FSSext(self.handle,v[0],v[1],v[2]))
+
+    def DSC(self, thetai=0, thetas=0, phis=0, rotation=0, coords="psps",
+            inc=StokesVector([1,0,0,0]),sens=StokesVector([1,0,0,0])):
+        """
+        Return the differential scattering cross section in a given geometry.
+
+        Parameters
+        ----------
+        thetai : float
+            Polar angle of incidence in radians
+
+        thetas : float
+            Polar angle of viewing in radians 
+
+        phis : float
+            Azimuthal angle of viewing in radians 
+            (Note: Specular occurs when thetai = thetas, phis = 0)
+
+        rotation : float
+            Sample rotation angle in radians
+
+        coords : string
+            The coordinate system for the Mueller matrix, 
+            either "psps", "xyxy", or "plane"
+
+        inc : StokesVector
+            Incident polarization as Stokes vector
+
+        sens : StokesVector
+            Polarization sensitivity of the viewer as a Stokes vector 
+
+        Returns
+        -------
+        r : float
+            The Mueller matrix differential scattering cross section for the 
+            given incident and viewing directions and polarizations
+        """
+        vin = [-np.sin(thetai),0,-np.cos(thetai)]
+        vout = [np.cos(phis)*np.sin(thetas), np.sin(phis)*np.sin(thetas), np.cos(thetas)]
+        return float((StokesVector(sens) @ 
+                      self.DifferentialScatteringCrossSection(vin,vout)) @ 
+                            StokesVector(inc).rotate(phis))


### PR DESCRIPTION
…the integrate module also with Mie scatterers, which is useful e.g. for assessing the intensity and polarization state of light bundled by a lens.

Please note the following: 
- The keyword arguments "rotation" and "coords" are not needed for the DSC function for Mie Scatterers. Nonetheless, I retained them, because removing them leads to issues when model.DSC is called. 